### PR TITLE
feat: Add authentication

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,10 @@
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
         <dependency>

--- a/src/main/java/org/hisp/dhis/integration/configuration/BasicAuthWebSecurityConfiguration.java
+++ b/src/main/java/org/hisp/dhis/integration/configuration/BasicAuthWebSecurityConfiguration.java
@@ -1,0 +1,44 @@
+package org.hisp.dhis.integration.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+
+/**
+ * @author Morten Svanæs <msvanaes@dhis2.org>
+ */
+@Configuration
+public class BasicAuthWebSecurityConfiguration
+{
+    @Bean
+    public SecurityFilterChain filterChain( HttpSecurity http )
+        throws Exception
+    {
+        http
+            .csrf().disable()
+            .authorizeRequests()
+            .antMatchers( "/auth/*" )
+            .permitAll()
+            .anyRequest().authenticated()
+            .and()
+            .httpBasic();
+
+        return http.build();
+    }
+
+    @Bean
+    public InMemoryUserDetailsManager userDetailsService()
+    {
+        UserDetails user = User
+            .withUsername( "user" )
+            .password( "{noop}password" )
+            .roles( "USER" )
+            .build();
+
+        return new InMemoryUserDetailsManager( user );
+    }
+}

--- a/src/main/java/org/hisp/dhis/integration/web/AuthController.java
+++ b/src/main/java/org/hisp/dhis/integration/web/AuthController.java
@@ -1,0 +1,41 @@
+package org.hisp.dhis.integration.web;
+
+import org.hisp.dhis.integration.domain.EmptyResponse;
+import org.hisp.dhis.integration.domain.Status;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * @author Morten Svanæs <msvanaes@dhis2.org>
+ */
+
+@RestController
+@RequestMapping( "/auth" )
+@RequiredArgsConstructor
+public class AuthController
+{
+    @PostMapping( "/register" )
+    public ResponseEntity<EmptyResponse> register( @RequestBody Integer phoneNumber )
+    {
+        EmptyResponse response = EmptyResponse.builder()
+            .status( Status.OK )
+            .build();
+
+        return ResponseEntity.ok( response );
+    }
+
+    @PostMapping( "/sendCode" )
+    public ResponseEntity<EmptyResponse> sendCode( @RequestBody Integer phoneNumber )
+    {
+        EmptyResponse response = EmptyResponse.builder()
+            .status( Status.OK )
+            .build();
+
+        return ResponseEntity.ok( response );
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,3 +5,5 @@ self-reporting.program-id=IpHINAT79UW
 self-reporting.first-name-attribute=w75KJ2mc4zz
 self-reporting.last-name-attribute=zDhUuAYrxNC
 self-reporting.dob-attribute=iESIqZ0R0R0
+self-reporting.phoneAttribute=iESIqZ0R0R0
+self-reporting.emailAttribute=iESIqZ0R0R0


### PR DESCRIPTION
### Summary

This adds HTTP Basic auth to all endpoints except /auth/*
The username and password is hard-coded and is user:password
The /registration and /sendCode endpoints is not doing anything now and just return 200, (which they always will do, unless there is an internal server error), they are intended to be using a sms gateway that will send a code to the user, and then be used as a code to either to generate a another password or as is, and the phone number could be used as the username.
Instead of implementing persistence in this app, it could potentially use DHIS2 teis API for persisting the phone number and the generated password.
